### PR TITLE
Don't always load map module.

### DIFF
--- a/byond/__init__.py
+++ b/byond/__init__.py
@@ -5,9 +5,6 @@ Created on Sep 21, 2013
 '''
 import os
 
-from byond.map import Map, Tile, MapRenderFlags
-from byond.objtree import ObjectTree
-
 def GetFilesFromDME(dmefile='baystation12.dme', ext='.dm'):
     filesInDME=[]
     rootdir = os.path.dirname(dmefile)


### PR DESCRIPTION
This saves quite a bit of time when using the library for something like DMI parsing only.